### PR TITLE
Add global template support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "conventionalCommits.scopes": [
         "install_scripts",
-        "wiki"
+        "wiki",
+        "init"
     ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,7 @@ name = "bonnie"
 version = "0.3.0"
 dependencies = [
  "dotenv",
+ "home",
  "regex",
  "serde",
  "serde_json",
@@ -27,6 +28,15 @@ name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
+name = "home"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "itoa"
@@ -137,3 +147,25 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,11 @@ edition = "2018"
 
 [dependencies]
 toml = "0.5.8"
-serde = { version = "1.0.125", features = ["derive"] }
+serde = { version="1.0.125", features=["derive"] }
 serde_json = "1.0.64"
 dotenv = "0.15.0"
 regex = "1.5.4"
+home = "0.5.3"
 
 [lib]
 name = "lib"

--- a/src/help.rs
+++ b/src/help.rs
@@ -11,7 +11,8 @@ This just summarizes the functionality of this command, not the syntax of Bonnie
 
 -h, --help                                      prints this help page
 -v, --version                                   prints the current version of Bonnie
--i, --init [-t, --template <template-file>]     creates a new `bonnie.toml` configuration, potentially taking a template file to use
+-i, --init [-t, --template <template-file>]     creates a new `bonnie.toml` configuration, using the specified template file if provided.
+-e, --edit-template                             opens your Bonnie init template file in your default editor
 -c, --cache                                     caches the Bonnie configuration file to `.bonnie.cache.json` for performance (this cache must be MANUALLY updated by re-running this command!)
 
 The expected location of a Bonnie configuration file can be changed from the default `./bonnie.toml` by setting the `BONNIE_CONF` environment variable.

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,10 +1,13 @@
+use crate::template;
 use crate::version::BONNIE_VERSION;
+
 use std::fs;
+use std::io;
 
 // Creates a new Bonnie configuration file using a template, or from the default
 pub fn init(template: Option<String>) -> Result<(), String> {
     // Check if there's already a config file in this directory
-    if fs::metadata("./bonnie.toml").is_ok() {
+    if fs::metadata("bonnie.toml").is_ok() {
         Err(String::from("A Bonnie configuration file already exists in this directory. If you want to create a new one, please delete the old one first."))
     } else {
         // Check if a template has been given
@@ -22,24 +25,29 @@ pub fn init(template: Option<String>) -> Result<(), String> {
             // We have a template file that doesn't exist
             return Err(format!("The given template file at '{}' does not exist or can't be read. Please make sure the file exists and you have the permissions necessary to read from it.", template.as_ref().unwrap()));
         } else {
-            // Create a new `bonnie.toml` file using the default
-            // TODO read the default from `~/.bonnie/template.toml` if it exists
-            output = fs::write(
-                "./bonnie.toml",
-                format!(
-                    "version=\"{version}\"
+            // get t
+            let template = match template::get_default() {
+                Ok(template) => Ok(template),
+                Err(template::Error::Other(err)) if err.kind() == io::ErrorKind::NotFound => {
+                    Ok(format!(
+                        "version=\"{version}\"
 
 [scripts]
 start = \"echo \\\"No start script yet!\\\"\"
-                ",
-                    version = BONNIE_VERSION
-                ),
-            );
+",
+                        version = BONNIE_VERSION
+                    ))
+                }
+                Err(err) => Err(err),
+            }
+            .map_err(|err| format!("{:#?}", err))?;
+
+            output = fs::write("bonnie.toml", template)
         }
 
         match output {
     		Ok(_) => Ok(()),
-    		Err(_) => Err(String::from("Error creating new bonnie.toml, make sure you have the permissions to write to this directory."))
+    		Err(_) => Err(format!("Error creating new bonnie.toml, make sure you have the permissions to write to this directory."))
     	}
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod help;
 mod init;
 mod raw_schema;
 mod schema;
+mod template;
 mod version;
 
 pub use crate::cache::{cache, cache_exists, load_from_cache};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,4 +15,5 @@ pub use crate::help::help;
 pub use crate::init::init;
 pub use crate::raw_schema::Config;
 pub use crate::schema::Config as FinalConfig;
+pub use crate::template::get_template_path;
 pub use crate::version::BONNIE_VERSION;

--- a/src/template.rs
+++ b/src/template.rs
@@ -11,14 +11,18 @@ pub enum Error {
     Other(io::Error),
 }
 
-pub fn get_default() -> Result<String, Error> {
+pub fn get_template_path() -> Result<PathBuf, Error> {
     let default_template_path = home_dir()
         .map(|x| x.join(".bonnie").join("template.toml"))
         .ok_or(Error::CouldNotGetHomeDirectory)?;
 
-    let path = env::var("BONNIE_TEMPLATE_PATH")
+    Ok(env::var("BONNIE_TEMPLATE_PATH")
         .map(|x| PathBuf::from(x))
-        .unwrap_or(default_template_path);
+        .unwrap_or(default_template_path))
+}
+
+pub fn get_default() -> Result<String, Error> {
+    let path = get_template_path()?;
 
     let template = fs::read_to_string(path);
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,0 +1,26 @@
+use home::home_dir;
+
+use std::env;
+use std::fs;
+use std::io;
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub enum Error {
+    CouldNotGetHomeDirectory,
+    Other(io::Error),
+}
+
+pub fn get_default() -> Result<String, Error> {
+    let default_template_path = home_dir()
+        .map(|x| x.join(".bonnie").join("template.toml"))
+        .ok_or(Error::CouldNotGetHomeDirectory)?;
+
+    let path = env::var("BONNIE_TEMPLATE_PATH")
+        .map(|x| PathBuf::from(x))
+        .unwrap_or(default_template_path);
+
+    let template = fs::read_to_string(path);
+
+    return template.map_err(|err| Error::Other(err));
+}


### PR DESCRIPTION
Closes #16.

I introduced the `home` crate to deal with finding the user's home directory on Windows, which is surprisingly tricky. Win32 API usage is required, which I didn't want to mess with.